### PR TITLE
JSON Patch draft 6 update

### DIFF
--- a/lib/jsonpatch.js
+++ b/lib/jsonpatch.js
@@ -25,14 +25,26 @@
  *
  * Implements the JSON Patch IETF Draft as specified at:
  *
- *   http://tools.ietf.org/html/draft-pbryan-json-patch-01
+ *   http://tools.ietf.org/html/draft-pbryan-json-patch-06
  *
  * Also implements the JSON Pointer IETF Draft as specified at:
  *
- *   http://tools.ietf.org/html/draft-pbryan-zyp-json-pointer-02
+ *   http://tools.ietf.org/html/draft-pbryan-zyp-json-pointer-05
  *
  */
-(function (exports) {
+
+(function (root, factory) {
+    if (typeof exports === 'object') {
+        // Node
+        factory(module.exports);
+    } else if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['exports'], factory);
+    } else {
+        // Browser globals (root is window)
+        root.returnExports = factory(root.jsonpatch);
+  }
+}(this, function (exports) {
   var apply_patch, JSONPatch, JSONPointer,_operations,isArray;
 
   // Taken from underscore.js
@@ -275,12 +287,18 @@
       return this.replace(doc, operation.value);
     },
     move: function(doc, operation) {
+      if(startsWith(operation.to, operation.path)) {
+        throw new InvalidPatch('destination must not be a child of path');
+      }
       var value = this.get(doc);
       var intermediate = this.remove(doc);
       var dest = new JSONPointer(operation.to);
       return dest.add(intermediate, value);
     },
     copy: function(doc, operation) {
+      if(startsWith(operation.to, operation.path)) {
+        throw new InvalidPatch('destination must not be a child of path');
+      }
       var value = this.get(doc);
       var dest = new JSONPointer(operation.to);
       return dest.add(doc, value);
@@ -290,6 +308,16 @@
     }
   };
 
+  function startsWith(str, strPrefix) {
+    return str.substr(0, strPrefix.length) === strPrefix;
+  }
+  function contains(arr, value) {
+    var i, len;
+    for(i = 0, len = arr.length; i < len; i++) {
+      if (arr[i] === value) return true;
+    }
+    return false;
+  }
 
   function compileOperation(operation) {
     var op = operation.op;
@@ -297,20 +325,6 @@
     return function (doc) {
       return _operations[op].call(path, doc, operation);
     };
-  }
-
-  function make_operation(pointer, method, value) {
-    return function (doc) {
-      return method.call(pointer, doc, value);
-    };
-  }
-
-  function contains(arr, value) {
-    var i, len;
-    for(i = 0, len = arr.length; i < len; i++) {
-      if (arr[i] === value) return true;
-    }
-    return false;
   }
 
   var operationRequired = {
@@ -326,11 +340,11 @@
     if (!operation.op) {
       throw new InvalidPatch('Operation missing!');
     }
-    if (!operation.path) {
-      throw new InvalidPatch('Path missing!');
-    }
     if (!operationRequired.hasOwnProperty(operation.op)) {
       throw new InvalidPatch('Invalid operation!');
+    }
+    if (!operation.path) {
+      throw new InvalidPatch('Path missing!');
     }
 
     for(key in operation) {
@@ -348,7 +362,6 @@
       }
     });
   }
-
 
   /* Public: A class representing a patch.
    *
@@ -392,4 +405,4 @@
     }
     return doc;
   };
-})('object' === typeof module ? module.exports : (window.jsonpatch = {}));
+}));

--- a/test/jsonpatch_spec.js
+++ b/test/jsonpatch_spec.js
@@ -329,12 +329,18 @@ describe('JSONPatch', function () {
 
   describe('to attribute', function () {
     it('MUST NOT be part of the location specified by "path" in a move operation', function () {
-      throw new Error("not implemented")
-    })
-    it('MUST NOT be part of the location specified by "path" in a move operation', function () {
-      throw new Error("not implemented")
-    })
-  })
+      var doc = {a:{b:true, c:false}};
+      expect(function () {
+        jsonpatch.apply_patch(doc, [{op: 'move', path: '/a', to: '/a/b'}]);
+      }).toThrow(new jsonpatch.InvalidPatch('destination must not be a child of path'));
+    });
+    it('MUST NOT be part of the location specified by "path" in a copy operation', function () {
+      var doc = {a:{b:true, c:false}};
+      expect(function () {
+        jsonpatch.apply_patch(doc, [{op: 'copy', path: '/a', to: '/a/b'}]);
+      }).toThrow(new jsonpatch.InvalidPatch('destination must not be a child of path'));
+    });
+  });
 
   describe('Regressions', function () {
     it('should reject unknown patch operations (even if they are properties of the base Object)', function () {
@@ -351,9 +357,16 @@ describe('JSONPatch', function () {
         "omega": "lots"
       };
 
-      jsonpatch.apply_patch(doc, [{"op": "replace", "path": "/beta/", "value": 2}]);
+      expect(function () {
+        jsonpatch.apply_patch(doc, [
+          {"op": "add", "path": "/delta", "value": 2},
+          {"op": "replace", "path": "/beta///", "value": 2}
+        ]);
+      }).toThrow(new Error('Path not found in document'));
+
 
       expect(doc.beta).toEqual(undefined);
+      //expect(doc.delta).toEqual(undefined);
     });
   });
 


### PR DESCRIPTION
Updated tests and implementation for JSON Patch 6 / JSON Pointer 5 Internet Drafts and related tests. This is still not complete, but it's a first crack. The format for JSON Patch operations reverted to {op: 'operation', path: '/json/pointer', value: 'foo' } format, and `move` and `copy` operators were added. This pull request addresses these changes.

There are some things not addressed in this PR. Specifically, the `test` operation in JSON Patch 6 is not implemented, nor is the `-` notation to signify the end of an array in JSON Pointer. I also want to clean up the implementation and implement a "safe" mode which will treat the original document as immutable and apply the patch to a cloned document.
