### PR TITLE
Escape closing script tags in comments.

### DIFF
--- a/lib/jsonpatch.js
+++ b/lib/jsonpatch.js
@@ -71,12 +71,12 @@
    *
    * Example (in browser)
    *
-   *     <script src="jsonpatch.js" type="text/javascript"></script>
+   *     <script src="jsonpatch.js" type="text/javascript"><\/script>
    *     <script type="application/javascript">
    *      doc = JSON.parse(sourceJSON);
    *      doc = jsonpatch.apply_patch(doc, thepatch);
    *      destJSON = JSON.stringify(doc);
-   *     </script>
+   *     <\/script>
    *
    * Returns the patched document
    */


### PR DESCRIPTION
It prevents unexpected closing the script when inlining the javascript.
