### PR TITLE
Update jsonpatch.js

### DIFF
--- a/lib/jsonpatch.js
+++ b/lib/jsonpatch.js
@@ -118,7 +118,7 @@
       throw new InvalidPatch('JSONPointer must start with a slash (or be an empty string)!');
     }
     for (i = 1; i < split.length; i++) {
-      path[i-1] = split[i].replace('~1','/').replace('~0','~');
+      path[i-1] = split[i].replace(/~1/g,'/').replace(/~0/g,'~');
     }
     this.path = path;
     this.length = path.length;


### PR DESCRIPTION
Replace recursively to avoid errors when there are multiple '~1' (/) or '~0' (~) in the same split fragment.
