### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.6"
+  - "0.12"
+  - "0.10"
+  - "iojs-v3.2.0"
+  - "iojs-v2.5.0"


### PR DESCRIPTION
Travis failed on node 0.8 and below because the associated npm versions are too old to understand caret ranges.