### PR TITLE
Added toString methods for JSONPatch and JSONPointer

### DIFF
--- a/lib/jsonpatch.js
+++ b/lib/jsonpatch.js
@@ -120,8 +120,13 @@
     for (i = 1; i < split.length; i++) {
       path[i-1] = split[i].replace(/~1/g,'/').replace(/~0/g,'~');
     }
+    this.pathStr = pathStr;
     this.path = path;
     this.length = path.length;
+  };
+
+  JSONPointer.prototype.toString = function() {
+    return this.pathStr;
   };
 
   /* Private: Get a segment of the pointer given a current doc
@@ -493,6 +498,17 @@
    */
   exports.JSONPatch = JSONPatch = function JSONPatch(patch, mutate) {
     this._compile(patch, mutate);
+    this._input = patch;
+  };
+
+  JSONPatch.prototype.toString = function() {
+    var stringValue;
+    if (typeof this._input === "string") {
+        stringValue = this._input;
+    } else {
+        stringValue = JSON.stringify(this._input);
+    }
+    return stringValue;
   };
 
   JSONPatch.prototype._compile = function (patch, mutate) {

--- a/test/test.jsonpatch.js
+++ b/test/test.jsonpatch.js
@@ -172,6 +172,22 @@ describe('JSONPointer', function () {
       expect(do_get).withArgs('/foo/bar', example).throwException(function (e) { expect(e).a(jsonpatch.PatchApplyError); expect(e.message).equal('Path not found in document') });
     });
   });
+
+  describe('.toString()', function () {
+    it('should return a string representation of the path', function() {
+       var pathInput = "/foo/~0bar/~1baz";
+       var path = new jsonpatch.JSONPointer(pathInput);
+
+       expect(path + "").equal(pathInput);
+    });
+
+    it('should handle being an empty string', function() {
+      var pathInput = "";
+      var path = new jsonpatch.JSONPointer(pathInput);
+
+      expect(path + "").equal(pathInput);
+    });
+  });
 });
 
 describe('JSONPatch', function () {
@@ -368,6 +384,23 @@ describe('JSONPatch', function () {
       expect(doc.beta).equal(undefined);
       //expect(doc.delta).equal(undefined);
     });
+  });
+
+  describe('.toString()', function () {
+    it('should return a string representation of the input that created the patch', function () {
+      var patchInput = '[{"op":"add","path":"/foo","value":"~0"}]';
+      var patch = new jsonpatch.JSONPatch(patchInput);
+
+      expect(patch + "").equal(patchInput);
+    });
+
+    it('should handle stringifying objects to generate the string representation', function () {
+      var patchString = '[{"op":"add","path":"/foo","value":"~0"}]';
+      var patchInput = JSON.parse(patchString);
+      var patch = new jsonpatch.JSONPatch(patchInput);
+
+      expect(patch + "").equal(patchString);
+    })
   });
 
 });


### PR DESCRIPTION
Adds the ability to convert patches and pointers back to strings, to allow passing around as real objects then serialising to the database.