### PR TITLE
No leading zeros

### DIFF
--- a/lib/jsonpatch.js
+++ b/lib/jsonpatch.js
@@ -133,8 +133,8 @@
       if ('-' === segment) {
         segment = node.length;
       } else {
-        // Must be a non-negative integer in base-10
-        if (!segment.match(/^[0-9]*$/)) {
+        // Must be a non-negative integer in base-10 without leading zeros
+        if (!segment.match(/^0|[1-9][0-9]*$/)) {
           throw new PatchApplyError('Expected a number to segment an array');
         }
         segment = parseInt(segment,10);

--- a/test/test.jsonpatch.js
+++ b/test/test.jsonpatch.js
@@ -144,10 +144,7 @@ describe('JSONPointer', function () {
         "/k\"l" :6,
         "/ "    :7,
         "/m~0n" :8,
-        "/m~0n~0o" :"blarg",
-        // Extra examples
-        "/numbers/010": 10,
-        "/numbers/00010": 10
+        "/m~0n~0o" :"blarg"
       };
 
       for (var example in examples) {


### PR DESCRIPTION
According to RFC 6901 leading zeros are not allowed.

Also, updated tests from the json-patch-tests project (in a separate commit).