### PR TITLE
Added basic math operation support for 'add' method

### DIFF
--- a/lib/jsonpatch.js
+++ b/lib/jsonpatch.js
@@ -238,7 +238,20 @@
         }
         node.splice(lastSegment, 0, value);
       } else {
-        node[lastSegment] = value;
+          if (['+=','-=','*=','/='].includes(value.substr(0,2))) {
+              value = ((mathOp, curVal, modifier) => {
+                  if (Number.isNaN(modifier)) {
+                      throw new PatchApplyError('Add operation with math must supply a numeric value after equals sign!');
+                  }
+                  switch (mathOp) {
+                      case '+': return curVal+modifier;
+                      case '-': return curVal-modifier;
+                      case '*': return curVal*modifier;
+                      case '/': return curVal/modifier;
+                  }
+              })(value.substr(0,1), (node[lastSegment] || 0), Number(value.substr(2)));
+          }
+          node[lastSegment] = value;
       }
       return node;
     }, mutate);


### PR DESCRIPTION
JSONPointer.prototype.add now supports basic mathematical operations as an input value.  e.g: a value of '+=1' would add 1 to the existing value (or add 1 to 0 if no value exists at path).

This arguably still conforms to the RFC 6902 standards, however could be considered as a stretch on JSON API standards.