### PR TITLE
Strictly type operations

### DIFF
--- a/lib/jsonpatch.d.ts
+++ b/lib/jsonpatch.d.ts
@@ -1,4 +1,41 @@
-export function apply_patch<D>(doc: D, patch: string | Array<any>): D;
+export interface AddOperation {
+  op: 'add';
+  path: string;
+  value: any;
+}
+
+export interface RemoveOperation {
+  op: 'remove';
+  path: string;
+}
+
+export interface ReplaceOperation {
+  op: 'replace';
+  path: string;
+  value: any;
+}
+
+export interface MoveOperation {
+  op: 'move';
+  path: string;
+  from: string;
+}
+
+export interface CopyOperation {
+  op: 'copy';
+  path: string;
+  from: string;
+}
+
+export interface TestOperation {
+  op: 'test';
+  path: string;
+  value: any;
+}
+
+export type Operation = AddOperation | RemoveOperation | ReplaceOperation | MoveOperation | CopyOperation | TestOperation;
+
+export function apply_patch<D>(doc: D, patch: string | Array<Operation>): D;
 
 export interface InvalidPatch extends Error {
   new (message: string): InvalidPatch;
@@ -18,6 +55,6 @@ export interface JSONPointer {
 }
 
 export interface JSONPatch {
-  new (patch: string | Array<any>, mutate?: boolean): JSONPatch;
+  new (patch: string | Array<Operation>, mutate?: boolean): JSONPatch;
   apply<D>(doc: D): D;
 }


### PR DESCRIPTION
With these additional typings it won't be possible to use incorrect values for the operations as shown below:

![image](https://github.com/user-attachments/assets/d95158c7-4305-4445-91c1-69d0ee30900e)
